### PR TITLE
Fixed mismatched function name in code example.

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
         // what code goes here?
     }
 
-    test("FooBar"); // to get the console to say "FooBar"
+    fooBarConsoleTest("FooBar"); // to get the console to say "FooBar"
                         </code></pre>
 
                         <pre class="fragment"><code>
@@ -156,7 +156,7 @@
         console.log(arguments[0]);
     }
 
-    test("FooBar");
+    fooBarConsoleTest("FooBar");
                         </code></pre>
 
                         <aside class="notes">


### PR DESCRIPTION
I noticed during your talk at the Great Lakes Area .NET User Group that in your code examples you defined a function called `fooBarConsoleTest`, but you were attempting to call it as just `test`. This pull request corrects that mismatch.
